### PR TITLE
Switch initialization of apps and db sources

### DIFF
--- a/bootstrap.php
+++ b/bootstrap.php
@@ -92,16 +92,6 @@ abstract class RecessConf {
 		Library::init();
 		Library::beginNamedRun('recess');
 		
-		Library::import('recess.framework.Application');
-		foreach(self::$applications as $key => $app) {
-			if(!Library::classExists($app)) {
-				die('Application "' . $app . '" does not exist. Remove it from recess-conf.php, RecessConf::$applications array.');
-			} else {
-				$app = Library::getClassName($app);
-				self::$applications[$key] = new $app;
-			}
-		}
-		
 		Library::import('recess.database.Databases');
 		Library::import('recess.database.orm.ModelDataSource');
 		
@@ -148,6 +138,16 @@ abstract class RecessConf {
 		if(!empty(RecessConf::$namedDatabases)) {
 			foreach(RecessConf::$namedDatabases as $name => $sourceInfo) {
 				Databases::addSource($name, new ModelDataSource($sourceInfo));
+			}
+		}
+
+                Library::import('recess.framework.Application');
+		foreach(self::$applications as $key => $app) {
+			if(!Library::classExists($app)) {
+				die('Application "' . $app . '" does not exist. Remove it from recess-conf.php, RecessConf::$applications array.');
+			} else {
+				$app = Library::getClassName($app);
+				self::$applications[$key] = new $app;
 			}
 		}
 		


### PR DESCRIPTION
This is just to switch db source and application construction initialization, so that databases will be in place for any application logic that needs access to models. 

There may be a cleaner solution if there was a place in the application class to put logic that should be called before controllers (since plugins don't necessarily work for this either).
