### PR TITLE
Better implementation of count() in PdoDataSet and PdoDataSource

### DIFF
--- a/bootstrap.php
+++ b/bootstrap.php
@@ -92,16 +92,6 @@ abstract class RecessConf {
 		Library::init();
 		Library::beginNamedRun('recess');
 		
-		Library::import('recess.framework.Application');
-		foreach(self::$applications as $key => $app) {
-			if(!Library::classExists($app)) {
-				die('Application "' . $app . '" does not exist. Remove it from recess-conf.php, RecessConf::$applications array.');
-			} else {
-				$app = Library::getClassName($app);
-				self::$applications[$key] = new $app;
-			}
-		}
-		
 		Library::import('recess.database.Databases');
 		Library::import('recess.database.orm.ModelDataSource');
 		
@@ -148,6 +138,16 @@ abstract class RecessConf {
 		if(!empty(RecessConf::$namedDatabases)) {
 			foreach(RecessConf::$namedDatabases as $name => $sourceInfo) {
 				Databases::addSource($name, new ModelDataSource($sourceInfo));
+			}
+		}
+
+                Library::import('recess.framework.Application');
+		foreach(self::$applications as $key => $app) {
+			if(!Library::classExists($app)) {
+				die('Application "' . $app . '" does not exist. Remove it from recess-conf.php, RecessConf::$applications array.');
+			} else {
+				$app = Library::getClassName($app);
+				self::$applications[$key] = new $app;
 			}
 		}
 		

--- a/recess/recess/database/pdo/PdoDataSet.class.php
+++ b/recess/recess/database/pdo/PdoDataSet.class.php
@@ -118,7 +118,7 @@ class PdoDataSet implements Iterator, Countable, ArrayAccess, ISqlSelectOptions,
 	}
 	
 	public function count() {
-		return iterator_count($this); 
+		return $this->source->getResultCount($this->sqlBuilder);
 	}
 	
 	public function exists() {

--- a/recess/recess/database/pdo/PdoDataSource.class.php
+++ b/recess/recess/database/pdo/PdoDataSource.class.php
@@ -90,7 +90,19 @@ class PdoDataSource extends PDO {
 			return new PdoDataSet($this);
 		}
 	}
-	
+
+	/* optimizes performance by NOT actually getting results
+	 * useful for paging large result sets
+	 * @param SqlBuilder $builder
+	 * @param string $className
+	 * @return integer $resultCount
+	 * */
+	function getResultCount(SqlBuilder $builder) {
+			$statement = $this->provider->getStatementForBuilder($builder, 'select', $this);
+			$statement->execute();
+			return $statement->rowCount();		
+	}
+
 	/**
 	 * Takes the SQL and arguments (array of Criterion) and returns an array
 	 * of objects of type $className.


### PR DESCRIPTION
The current implementation of count() in PdoDataSet causes memory allocation problems with large result sets.  This implementation utilizes PDOStatement::rowCount(), and does not return results, which is really useful when you want to page 30,000 results, or at least know how many there are.  

Currently, Recess actually retrieves those results, and then iterates over the long array, which causes a crash, which seems to be related linearly to result-size/memory-available.

2 files were changed, PdoDataSet and PdoDataSource
